### PR TITLE
Ensure strong_parameters defines Parameters first

### DIFF
--- a/lib/cancan_strong_parameters/rails/controller/base.rb
+++ b/lib/cancan_strong_parameters/rails/controller/base.rb
@@ -1,3 +1,5 @@
+require 'strong_parameters'
+
 class ActionController::Base
   include CancanStrongParameters::Controller
 end


### PR DESCRIPTION
It seems that in my setup bundler was causing cancan_strong_parameters to be required before strong_parameters.  So this file defined ActionController::Parameters as a new class, rather than including a module in an existing class.  Which meant that when strong_parameters tried to define ActionController::Parameters as a subclass of HashWithIndifferentAccess, ruby raised a 'superclass mismatch' error.  

Requiring 'strong_parameters' here fixed the problem for me.  (Though there may be more sophisticated ways of ensuring load order.)
