### PR TITLE
remove strong_parameter dependencies for rails 4 compatibility

### DIFF
--- a/cancan_strong_parameters.gemspec
+++ b/cancan_strong_parameters.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/colinyoung/cancan_strong_parameters"
   
   gem.add_dependency "cancan"
-  gem.add_dependency "strong_parameters", ">= 0.1.6"
   gem.add_dependency "activesupport"
   
   gem.add_development_dependency "require_all"

--- a/lib/cancan_strong_parameters/rails/controller/base.rb
+++ b/lib/cancan_strong_parameters/rails/controller/base.rb
@@ -1,5 +1,3 @@
-require 'strong_parameters'
-
 class ActionController::Base
   include CancanStrongParameters::Controller
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'require_all'
 
 require 'minitest/autorun'
 
-require 'strong_parameters'
 require 'cancan_strong_parameters'
 
 ## Boot up an instance of rails


### PR DESCRIPTION
Hi, 
  I've removed the requires for the strong_parameters gem, since it's included in Rails 4.
  I tested this on a few Rails 4 apps and it's working fine. 
  If you're interested in commiting this pull request, I think you should tag the current master head 
  as "rails_32" first, and then append  a note in the readme instructing people to use that commit
  for Rails 3.2 compatiblity.

Regards,

Sebastian.
