### PR TITLE
Failing test when only an Array param present

### DIFF
--- a/test/app/controllers/array_controller.rb
+++ b/test/app/controllers/array_controller.rb
@@ -1,0 +1,5 @@
+class ArrayController < PostsController
+  resource_name :post
+
+  permit_params label_ids: Array
+end

--- a/test/functional/array_controller_test.rb
+++ b/test/functional/array_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ArrayControllerTest < ActionController::TestCase
+
+  test "should allow only an Array param to be present" do
+
+    new_label_ids = [1, 2, 3]
+    put :update,
+      :id => 1,
+      :post => {
+        :comment_ids => new_label_ids
+      }
+
+    assert_equal assigns[:post].label_ids, new_label_ids
+  end
+
+end


### PR DESCRIPTION
I ran into an issue today while using `permit_params` like this:

``` ruby
permit_params label_ids: Array
```

We only needed to permit an array param. We're running version 0.3 and an `ActiveModel::ForbiddenAttributes` exception is thrown. I wrote a failing test for this (although I don't know if you'd want to include this - the naming is a bit poor here).

This isn't a huge issue for us, but I thought I'd share. We're using a workaround like this instead:

``` ruby
permit_params(
  :placeholder,
  label_ids: Array
)
```

Just let me know if a full pull request would be helpful. This might not be worth it as it might be an edge case for most people.
